### PR TITLE
안내종료 버그 수정

### DIFF
--- a/app/src/main/java/com/opensource/seebus/MainActivity.java
+++ b/app/src/main/java/com/opensource/seebus/MainActivity.java
@@ -17,13 +17,12 @@ import android.widget.Toast;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.messaging.FirebaseMessaging;
-import com.opensource.seebus.busRoute.BusRouteActivity;
 import com.opensource.seebus.history.HistoryActivity;
 import com.opensource.seebus.sendDeviceInfo.SendDeviceInfoRequestDto;
 import com.opensource.seebus.sendDeviceInfo.SendDeviceInfoResponseDto;
 import com.opensource.seebus.sendDeviceInfo.SendDeviceInfoService;
 import com.opensource.seebus.sendGpsInfo.SendGpsInfoActivity;
-import com.opensource.seebus.singletonRetrofit.SingletonRetrofit;
+import com.opensource.seebus.singleton.SingletonRetrofit;
 import com.opensource.seebus.startingPoint.StartingPointActivity;
 
 import androidx.annotation.NonNull;
@@ -195,20 +194,11 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onResponse(Call<SendDeviceInfoResponseDto> call, Response<SendDeviceInfoResponseDto> response) {
                 SendDeviceInfoResponseDto device = response.body();
-//                 AlertDialog.Builder dialog = new AlertDialog.Builder(MainActivity.this);
-//                 dialog.setTitle("알림!");
-//                 dialog.setMessage("androidId = " + device.androidId +
-//                         "\nfirebaseToken = " + device.firebaseToken +
-//                         "\nid = " + device.id +
-//                         "\n확인 링크 : " + getString(R.string.server_address) + "device" +
-//                         "\n도착여부 default=true : " + device.isArrived
-//                 );
-
-//                 dialog.show();
                 if(device.isArrived==false) {
                     Intent gpsIntent = new Intent(getApplicationContext(), SendGpsInfoActivity.class);
                     gpsIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK); // 기존의 액티비티 삭제
                     gpsIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK); // 새로운 액티비티 생성
+                    gpsIntent.putExtra("isReboot","Yes");
                     startActivity(gpsIntent);
                 }
             }

--- a/app/src/main/java/com/opensource/seebus/busRoute/BusRouteActivity.java
+++ b/app/src/main/java/com/opensource/seebus/busRoute/BusRouteActivity.java
@@ -2,10 +2,10 @@ package com.opensource.seebus.busRoute;
 
 import android.content.Intent;
 import android.graphics.Color;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.StrictMode;
 import android.provider.Settings;
-import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.AdapterView;
@@ -21,7 +21,7 @@ import com.opensource.seebus.history.DBHelper;
 import com.opensource.seebus.sendGpsInfo.SendGpsInfoActivity;
 import com.opensource.seebus.sendRouteInfo.SendRouteInfoRequestDto;
 import com.opensource.seebus.sendRouteInfo.SendRouteInfoService;
-import com.opensource.seebus.singletonRetrofit.SingletonRetrofit;
+import com.opensource.seebus.singleton.SingletonRetrofit;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -35,7 +35,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import androidx.appcompat.app.AppCompatActivity;
-
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -154,7 +153,9 @@ public class BusRouteActivity extends AppCompatActivity  implements View.OnClick
         textView.setGravity(Gravity.CENTER);
         textView.setTextColor(Color.parseColor("#FFFF00"));
         textView.setClickable(true);
-        textView.setFontFeatureSettings("R.font.font");
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            textView.setFontFeatureSettings(String.valueOf(R.font.font));
+        }
 
         listView.addHeaderView(textView);
         ListAdapter oAdapter = new BusRouteCustomView(listViewData);
@@ -200,6 +201,7 @@ public class BusRouteActivity extends AppCompatActivity  implements View.OnClick
                     Intent gpsIntent = new Intent(BusRouteActivity.this, SendGpsInfoActivity.class);
                     gpsIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK); // 기존의 액티비티 삭제
                     gpsIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK); // 새로운 액티비티 생성
+                    gpsIntent.putExtra("isReboot","No");
                     startActivity(gpsIntent);
                 } else { // 통신 실패(응답 코드로 판단)
                     // 확인용 toast

--- a/app/src/main/java/com/opensource/seebus/singleton/SingletonRetrofit.java
+++ b/app/src/main/java/com/opensource/seebus/singleton/SingletonRetrofit.java
@@ -1,4 +1,4 @@
-package com.opensource.seebus.singletonRetrofit;
+package com.opensource.seebus.singleton;
 
 import android.content.Context;
 

--- a/app/src/main/java/com/opensource/seebus/singleton/SingletonTimer.java
+++ b/app/src/main/java/com/opensource/seebus/singleton/SingletonTimer.java
@@ -1,0 +1,19 @@
+package com.opensource.seebus.singleton;
+
+import android.content.Context;
+
+import java.util.Timer;
+
+public class SingletonTimer {
+    //보통의 싱글턴이면 private였어야하지만 사용용도에 맞춰 public으로 변경
+    public static Timer singletonTimer = null;
+
+    private SingletonTimer() { }
+    public static synchronized Timer getInstance(Context context) {
+        if (singletonTimer == null) {
+            Timer timer = new Timer();
+            singletonTimer = timer;
+        }
+        return singletonTimer;
+    }
+}


### PR DESCRIPTION
## 개요
안내종료 버그 수정
## 작업사항
목적지 경로 설정 후 앱 재시작한 다음 안내종료를 누르면 계속해서 사용자 위치를 서버로 보내는 문제가 생김.
timer 객체가 앱을 재시작하면 기존에 만든 거는 남아서 5초마다 계속 위치를 서버로 보내고 재시작하면서 새롭게 생긴 객체가 또 위치를 서버로 보냄.
이러한 문제점을 해결하기 위해 싱글턴을 사용했는데 싱글턴 변수를 private로 하지 않고 public으로 함으로써 문제를 해결함.
timer 객체를 삭제하면 밑의 timerTask객체도 같이 삭제되는 거로 확인되어서 timer객체만 timer.cancel() 으로 삭제해줌.